### PR TITLE
Changes to settings layout and loading to be a more production ready implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ staticfiles
 env_vars.ps1
 .vscode
 *.code-workspace
+*/settings/local.py

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'villageline.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'villageline.settings.local')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/villageline/asgi.py
+++ b/villageline/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'villageline.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'villageline.settings.local')
 
 application = get_asgi_application()

--- a/villageline/settings/local.py.example
+++ b/villageline/settings/local.py.example
@@ -1,6 +1,7 @@
 from settings import *
 
 # SECRET_KEY =
+# ALLOWED_HOSTS = []
 # TWILIO_ACCOUNT_SID = ""
 # TWILIO_AUTH_TOKEN = ""
 # SENDGRID_API_KEY = ""

--- a/villageline/settings/local.py.example
+++ b/villageline/settings/local.py.example
@@ -1,0 +1,7 @@
+from settings import *
+
+# SECRET_KEY =
+# TWILIO_ACCOUNT_SID = ""
+# TWILIO_AUTH_TOKEN = ""
+# SENDGRID_API_KEY = ""
+# PYTHONBREAKPOINT = "IPython.embed"

--- a/villageline/settings/local.py.example
+++ b/villageline/settings/local.py.example
@@ -1,4 +1,4 @@
-from settings import *
+from .settings import *
 
 # SECRET_KEY =
 # ALLOWED_HOSTS = []

--- a/villageline/settings/local.py.example
+++ b/villageline/settings/local.py.example
@@ -5,4 +5,3 @@ from .settings import *
 # TWILIO_ACCOUNT_SID = ""
 # TWILIO_AUTH_TOKEN = ""
 # SENDGRID_API_KEY = ""
-# PYTHONBREAKPOINT = "IPython.embed"

--- a/villageline/settings/settings.py
+++ b/villageline/settings/settings.py
@@ -23,7 +23,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = DEBUG = os.environ.get('DJANGO_DEBUG', '') == 'True'
+# Default to False, override in local.py
+DEBUG = False
 
 # Forgery protection off at present as we only tell Twilio what to dial in a response.
 DJANGO_TWILIO_FORGERY_PROTECTION = False
@@ -133,7 +134,6 @@ STATIC_URL = '/static/'
 LOGIN_REDIRECT_URL = '/'
 
 EMAIL_BACKEND = "sendgrid_backend.SendgridBackend"
-SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY")
 DEFAULT_FROM_EMAIL = "Default Mail <default@domain.local>"
 
 # For testing password reset.
@@ -146,6 +146,3 @@ SERVER_EMAIL = "default@domain.local"
 ADMINS = [
     ('Admin name', 'admin@domain.local')
 ]
-
-import django_heroku
-django_heroku.settings(locals())

--- a/villageline/settings/settings.py
+++ b/villageline/settings/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+SECRET_KEY = None
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # Default to False, override in local.py

--- a/villageline/wsgi.py
+++ b/villageline/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'villageline.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'villageline.settings.local')
 
 application = get_wsgi_application()


### PR DESCRIPTION
This PR does the following:

- Removes support for heroku (at least from the `settings.py` file)
- Adds a settings directory and moves the settings.py file there as well as creating a local.py.example file
- Makes the default settings load in wsgi and asgi the `setttings/local.py` file
- Adds an exclusion to git so that local dev versions of `settings/local.py` aren't accidentally committed to the repo.