### PR TITLE
Remove requirements.txt and move to using base/dev/prod requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-django
-gunicorn
-django-heroku
-django-twilio
-django-solo
-django-phonenumber-field
-pytz
-django-sendgrid-v5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,6 @@
+django
+django-phonenumber-field
+django-sendgrid-v5
+django-solo
+django-twilio
+pytz

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,3 @@
+-r base.txt
+black
+isort

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,0 +1,2 @@
+-r base.txt
+gunicorn


### PR DESCRIPTION
Generally, there are requirements that you want in dev, not in production, and vice-versa, quite often there are dependencies that only make sense in production and not in your local dev.